### PR TITLE
Fix for page.destination using platform-specific separator instead of always '/'

### DIFF
--- a/es5/filePipelineSteps.js
+++ b/es5/filePipelineSteps.js
@@ -52,7 +52,7 @@ var addPageMetadata = exports.addPageMetadata = (0, _curry2.default)(function (f
         basename: _path2.default.basename(filePath, _path2.default.extname(filePath)), // 'quux'
         dirname: _path2.default.dirname(filePath), // '/foo/bar/baz/asdf'
         ext: _path2.default.extname(filePath), // '.md'
-        destination: _path2.default.join('/', filePath.substring(0, filePath.length - _path2.default.extname(filePath).length) + '.html') // '/foo/bar/baz/asdf/quux.html'
+        destination: _path2.default.posix.join('/', filePath.substring(0, filePath.length - _path2.default.extname(filePath).length) + '.html') // '/foo/bar/baz/asdf/quux.html'
     };
     return (0, _util.merge)(postMatter, { data: { page: page } });
 });

--- a/es6/filePipelineSteps.js
+++ b/es6/filePipelineSteps.js
@@ -22,7 +22,7 @@ export const addPageMetadata = curry((filePath, postMatter) => {
         basename: path.basename(filePath, path.extname(filePath)), // 'quux'
         dirname: path.dirname(filePath),  // '/foo/bar/baz/asdf'
         ext: path.extname(filePath), // '.md'
-        destination: path.join('/', filePath.substring(0, filePath.length - path.extname(filePath).length) + '.html') // '/foo/bar/baz/asdf/quux.html'
+        destination: path.posix.join('/', filePath.substring(0, filePath.length - path.extname(filePath).length) + '.html') // '/foo/bar/baz/asdf/quux.html'
     };
     return merge(postMatter, { data: {page} });
 });


### PR DESCRIPTION
Small fix for page destination - since we are constructing URLs we are not concerned with platform-specific separators and always want to use /
